### PR TITLE
Add optional dependencies and update ResizablePanel default size

### DIFF
--- a/mano-ui/package.json
+++ b/mano-ui/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview",
     "tauri": "tauri"
   },
+  "optionalDependencies": {
+    "@esbuild/win32-x64": "^0.25.12"
+  },
   "dependencies": {
     "@ai-sdk/react": "2.0.28",
     "@ariakit/react": "^0.4.20",
@@ -92,6 +95,7 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
+    "@rollup/rollup-win32-arm64-msvc": "^4.53.3",
     "@eslint/js": "^9.39.1",
     "@types/lodash": "^4.17.21",
     "@types/node": "^24.10.1",

--- a/mano-ui/pnpm-lock.yaml
+++ b/mano-ui/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
+      '@rollup/rollup-win32-arm64-msvc':
+        specifier: ^4.53.3
+        version: 4.53.3
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.9.5
@@ -294,6 +297,10 @@ importers:
       vite:
         specifier: ^7.2.4
         version: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)
+    optionalDependencies:
+      '@esbuild/win32-x64':
+        specifier: ^0.25.12
+        version: 0.25.12
 
 packages:
 
@@ -4758,8 +4765,7 @@ snapshots:
   '@rollup/rollup-openharmony-arm64@4.53.3':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.53.3':
-    optional: true
+  '@rollup/rollup-win32-arm64-msvc@4.53.3': {}
 
   '@rollup/rollup-win32-ia32-msvc@4.53.3':
     optional: true

--- a/mano-ui/src/components/ide/IDELayout.tsx
+++ b/mano-ui/src/components/ide/IDELayout.tsx
@@ -1422,10 +1422,11 @@ function IDELayoutContent() {
               
               <ResizablePanel 
                 ref={panelRef}
-                defaultSize={30} 
+                defaultSize={0} 
                 minSize={10} 
                 maxSize={60}
                 collapsible={true}
+                collapsedSize={0}
                 onCollapse={() => setIsPanelCollapsed(true)}
                 onExpand={() => setIsPanelCollapsed(false)}
               >


### PR DESCRIPTION
- Add `@esbuild/win32-x64` and `@rollup/rollup-win32-arm64-msvc` as optional dependencies
- Set `defaultSize` and `collapsedSize` to 0 for ResizablePanel in IDELayout