### PR TITLE
Refactor examples and update component styles

### DIFF
--- a/mano-ui/examples/第一回_灵根育孕源流出_心性修持大道生.mano
+++ b/mano-ui/examples/第一回_灵根育孕源流出_心性修持大道生.mano
@@ -39,10 +39,10 @@
     "type": "p",
     "children": [
       {
-        "text": ""
+        "text": "欲知造化会元功，须看《西游释厄传》。"
       }
     ],
-    "id": "OznEAH5ej2"
+    "id": "2Ox0fT7qkV"
   },
   {
     "type": "p",
@@ -51,16 +51,7 @@
         "text": "欲知造化会元功，须看《西游释厄传》。"
       }
     ],
-    "id": "2Ox0fT7qkV"
-  },
-  {
-    "type": "p",
-    "id": "uLW5c2Ht12",
-    "children": [
-      {
-        "text": ""
-      }
-    ]
+    "id": "PKq4qwUkyn"
   },
   {
     "type": "p",
@@ -68,6 +59,15 @@
     "children": [
       {
         "text": "本书完。"
+      }
+    ]
+  },
+  {
+    "type": "p",
+    "id": "QQ5nBiQaBc",
+    "children": [
+      {
+        "text": ""
       }
     ]
   }

--- a/mano-ui/src/components/editor/TextEditor.tsx
+++ b/mano-ui/src/components/editor/TextEditor.tsx
@@ -129,8 +129,8 @@ export function AutoSaveTextEditor({
 
   return (
     <Plate editor={plateEditor} onChange={handleChange} readOnly={readOnly}>
-      <EditorContainer variant="demo" className="bg-background">
-        <Editor variant="demo" />
+      <EditorContainer className="bg-background">
+        <Editor />
       </EditorContainer>
     </Plate>
   )

--- a/mano-ui/src/components/ide/EditorGroupWrapper.tsx
+++ b/mano-ui/src/components/ide/EditorGroupWrapper.tsx
@@ -155,7 +155,7 @@ export function EditorGroupWrapper({ group }: EditorGroupWrapperProps) {
         <div 
           ref={setDropRef}
           onClick={handleFocus} 
-          className={`h-full transition-all ${isFocused ? '' : 'opacity-60'} ${isOver ? 'ring-2 ring-primary ring-inset' : ''}`}
+          className={`h-full min-h-0 transition-all ${isFocused ? '' : 'opacity-60'} ${isOver ? 'ring-2 ring-primary ring-inset' : ''}`}
         >
           <Tabs value={group.activeTabId || undefined} onValueChange={handleFileSelect} className="h-full flex flex-col">
             <div className={`h-10 rounded-none justify-start border-b flex items-center transition-colors ${
@@ -185,7 +185,7 @@ export function EditorGroupWrapper({ group }: EditorGroupWrapperProps) {
             if (!model) return null
 
             return (
-              <TabsContent key={tab.id} value={tab.id} className="flex-1 m-0">
+              <TabsContent key={tab.id} value={tab.id} className="flex-1 m-0 min-h-0">
                 <AutoSaveTextEditor
                   key={model.id}
                   value={model.content}

--- a/mano-ui/src/components/ui/tabs.tsx
+++ b/mano-ui/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ function Tabs({
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn("flex flex-col gap-2 min-h-0", className)}
       {...props}
     />
   )
@@ -57,7 +57,7 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("flex-1 outline-none", className)}
+      className={cn("flex-1 min-h-0 outline-none", className)}
       {...props}
     />
   )


### PR DESCRIPTION
- Remove empty text nodes in `第一回_灵根育孕源流出_心性修持大道生.mano` example
- Update `TextEditor` to remove variant prop and simplify container
- Add `min-h-0` to `EditorGroupWrapper` and `tabs` components for better layout control